### PR TITLE
use default PageNumberPagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Possible Error Codes:
 
 #### Pagination
 
-Pagination available using `limit` and `page` as query param on endpoints that specify `paginated`. Default `limit` is 30.
+Pagination available using `page` and `page_size` as query param on endpoints that specify `paginated`. Default `page_size` is 30.
 
 Endpoints that support pagination will return a success response containing the following:
 

--- a/accounts/api.py
+++ b/accounts/api.py
@@ -14,6 +14,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from api.pagination import pagination_parameters
 from base.logging import logger
 from donations.models import Donation
 from donations.serializers import (
@@ -41,7 +42,6 @@ from .serializers import (
     AccountSerializer,
     PaginatedAccountsResponseSerializer,
 )
-from api.pagination import ResultPagination
 
 
 class DonorsAPI(APIView, PageNumberPagination):
@@ -53,7 +53,8 @@ class DonorsAPI(APIView, PageNumberPagination):
                 type=str,
                 location=OpenApiParameter.QUERY,
                 description="Sort by field, e.g., most_donated_usd",
-            )
+            ),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -88,9 +89,12 @@ class DonorsAPI(APIView, PageNumberPagination):
         return self.get_paginated_response(serializer.data)
 
 
-class AccountsListAPI(APIView, ResultPagination):
+class AccountsListAPI(APIView, PageNumberPagination):
 
     @extend_schema(
+        parameters=[
+            *pagination_parameters,
+        ],
         responses={
             200: OpenApiResponse(
                 response=PaginatedAccountsResponseSerializer,
@@ -106,7 +110,7 @@ class AccountsListAPI(APIView, ResultPagination):
                 ],
             ),
             500: OpenApiResponse(description="Internal server error"),
-        }
+        },
     )
     @method_decorator(cache_page(60 * 5))
     def get(self, request: Request, *args, **kwargs):
@@ -165,6 +169,7 @@ class AccountActivePotsAPI(APIView, PageNumberPagination):
                 required=False,
                 description="Filter by pot status",
             ),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -220,6 +225,7 @@ class AccountPotApplicationsAPI(APIView, PageNumberPagination):
                 OpenApiParameter.QUERY,
                 description="Filter pot applications by status",
             ),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -268,6 +274,7 @@ class AccountDonationsReceivedAPI(APIView, PageNumberPagination):
     @extend_schema(
         parameters=[
             OpenApiParameter("account_id", str, OpenApiParameter.PATH),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -308,6 +315,7 @@ class AccountDonationsSentAPI(APIView, PageNumberPagination):
     @extend_schema(
         parameters=[
             OpenApiParameter("account_id", str, OpenApiParameter.PATH),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -348,6 +356,7 @@ class AccountPayoutsReceivedAPI(APIView, PageNumberPagination):
     @extend_schema(
         parameters=[
             OpenApiParameter("account_id", str, OpenApiParameter.PATH),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -1,6 +1,17 @@
-from rest_framework.pagination import PageNumberPagination
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter
 
-class ResultPagination(PageNumberPagination):
-    page_size = 30
-    page_size_query_param = 'limit'
-    max_page_size = 200
+pagination_parameters = [
+    OpenApiParameter(
+        "page",
+        OpenApiTypes.INT,
+        OpenApiParameter.QUERY,
+        description="Page number for pagination",
+    ),
+    OpenApiParameter(
+        "page_size",
+        OpenApiTypes.INT,
+        OpenApiParameter.QUERY,
+        description="Number of results per page",
+    ),
+]

--- a/base/api.py
+++ b/base/api.py
@@ -9,7 +9,6 @@ from drf_spectacular.utils import (
     extend_schema,
 )
 from rest_framework import serializers
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/base/serializers.py
+++ b/base/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 
-class ResultPagination(serializers.DecimalField):
+class TwoDecimalPlacesField(serializers.DecimalField):
     def to_representation(self, value):
         if value is None:
             return value

--- a/base/settings.py
+++ b/base/settings.py
@@ -111,7 +111,7 @@ INSTALLED_APPS = [
 DEFAULT_PAGE_SIZE = 30
 
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "api.pagination.ResultPagination",
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": DEFAULT_PAGE_SIZE,
     "DEFAULT_THROTTLE_CLASSES": [
         # "rest_framework.throttling.UserRateThrottle",

--- a/donations/api.py
+++ b/donations/api.py
@@ -13,6 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from api.pagination import pagination_parameters
 from base.logging import logger
 
 from .serializers import DonationContractConfigSerializer
@@ -23,6 +24,9 @@ DONATE_CONTRACT = "donate." + settings.POTLOCK_TLA
 class DonationContractConfigAPI(APIView, PageNumberPagination):
 
     @extend_schema(
+        parameters=[
+            *pagination_parameters,
+        ],
         responses={
             200: OpenApiResponse(
                 response=DonationContractConfigSerializer,
@@ -43,7 +47,7 @@ class DonationContractConfigAPI(APIView, PageNumberPagination):
                 ],
             ),
             500: OpenApiResponse(description="Internal server error"),
-        }
+        },
     )
     @method_decorator(cache_page(60 * 5))
     def get(self, request: Request, *args, **kwargs):

--- a/pots/api.py
+++ b/pots/api.py
@@ -19,6 +19,7 @@ from accounts.serializers import (
     AccountSerializer,
     PaginatedAccountsResponseSerializer,
 )
+from api.pagination import pagination_parameters
 from donations.models import Donation
 from donations.serializers import (
     PAGINATED_DONATION_EXAMPLE,
@@ -47,6 +48,9 @@ from .serializers import (
 class PotsListAPI(APIView, PageNumberPagination):
 
     @extend_schema(
+        parameters=[
+            *pagination_parameters,
+        ],
         responses={
             200: OpenApiResponse(
                 response=PaginatedPotsResponseSerializer,
@@ -61,7 +65,7 @@ class PotsListAPI(APIView, PageNumberPagination):
                     ),
                 ],
             ),
-        }
+        },
     )
     @method_decorator(cache_page(60 * 5))
     def get(self, request: Request, *args, **kwargs):
@@ -74,6 +78,9 @@ class PotsListAPI(APIView, PageNumberPagination):
 class PotFactoriesAPI(APIView, PageNumberPagination):
 
     @extend_schema(
+        parameters=[
+            *pagination_parameters,
+        ],
         responses={
             200: OpenApiResponse(
                 response=PaginatedPotFactoriesResponseSerializer,
@@ -88,7 +95,7 @@ class PotFactoriesAPI(APIView, PageNumberPagination):
                     ),
                 ],
             ),
-        }
+        },
     )
     @method_decorator(cache_page(60 * 5))
     def get(self, request: Request, *args, **kwargs):
@@ -137,6 +144,7 @@ class PotApplicationsAPI(APIView, PageNumberPagination):
     @extend_schema(
         parameters=[
             OpenApiParameter("pot_id", str, OpenApiParameter.PATH),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -174,6 +182,7 @@ class PotDonationsAPI(APIView, PageNumberPagination):
     @extend_schema(
         parameters=[
             OpenApiParameter("pot_id", str, OpenApiParameter.PATH),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -211,6 +220,7 @@ class PotSponsorsAPI(APIView, PageNumberPagination):
     @extend_schema(
         parameters=[
             OpenApiParameter("pot_id", str, OpenApiParameter.PATH),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(
@@ -253,6 +263,7 @@ class PotPayoutsAPI(APIView, PageNumberPagination):
     @extend_schema(
         parameters=[
             OpenApiParameter("pot_id", str, OpenApiParameter.PATH),
+            *pagination_parameters,
         ],
         responses={
             200: OpenApiResponse(

--- a/pots/serializers.py
+++ b/pots/serializers.py
@@ -2,15 +2,15 @@ from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
 from accounts.serializers import SIMPLE_ACCOUNT_EXAMPLE, AccountSerializer
-from base.serializers import ResultPagination
+from base.serializers import TwoDecimalPlacesField
 from tokens.serializers import SIMPLE_TOKEN_EXAMPLE, TokenSerializer
 
 from .models import Pot, PotApplication, PotFactory, PotPayout
 
 
 class PotSerializer(ModelSerializer):
-    total_matching_pool_usd = ResultPagination(max_digits=20, decimal_places=2)
-    total_public_donations_usd = ResultPagination(max_digits=20, decimal_places=2)
+    total_matching_pool_usd = TwoDecimalPlacesField(max_digits=20, decimal_places=2)
+    total_public_donations_usd = TwoDecimalPlacesField(max_digits=20, decimal_places=2)
 
     class Meta:
         model = Pot
@@ -71,14 +71,13 @@ class PotFactorySerializer(ModelSerializer):
             "deployed_at",
             "protocol_fee_basis_points",
             "require_whitelist",
-            "protocol_fee_recipient"
+            "protocol_fee_recipient",
         ]
 
     owner = AccountSerializer()
     protocol_fee_recipient = AccountSerializer()
     admins = AccountSerializer(many=True)
     whitelisted_deployers = AccountSerializer(many=True)
-
 
 
 class PotApplicationSerializer(ModelSerializer):
@@ -122,7 +121,6 @@ class PotPayoutSerializer(ModelSerializer):
 EXAMPLE_POT_ID = "some-pot.v1.potfactory.potlock.near"
 
 EXAMPLE_POT_FACTORY_ID = "v1.potfactory.potlock.near"
-
 
 
 SIMPLE_POT_EXAMPLE = {
@@ -188,15 +186,16 @@ SIMPLE_POT_FACTORY_EXAMPLE = {
     "admins": [SIMPLE_ACCOUNT_EXAMPLE],
     "whitelisted_deployers": [SIMPLE_ACCOUNT_EXAMPLE],
     "source_metadata": {
-    "link": "https://github.com/PotLock/core",
+        "link": "https://github.com/PotLock/core",
         "version": "1.0.0",
-        "commit_hash": "e6b108e9442920333b44eb1a4068b9b9ae551d79"
+        "commit_hash": "e6b108e9442920333b44eb1a4068b9b9ae551d79",
     },
     "deployed_at": "2024-02-12T13:49:58.940854Z",
     "protocol_fee_basis_points": 200,
     "require_whitelist": False,
-    "protocol_fee_recipient": SIMPLE_ACCOUNT_EXAMPLE
+    "protocol_fee_recipient": SIMPLE_ACCOUNT_EXAMPLE,
 }
+
 
 class PaginatedPotFactoriesResponseSerializer(serializers.Serializer):
     count = serializers.IntegerField()


### PR DESCRIPTION
- revert custom `ResultPagination` to use Django's default `PageNumberPagination`
- add pagination query params to OpenAPI schemas