### PR TITLE
Add campaign data to daily Signal metrics and move send time to 07:00 UTC

### DIFF
--- a/base/api.py
+++ b/base/api.py
@@ -1,5 +1,8 @@
+import logging
+import os
 from datetime import timedelta
 
+import requests
 from django.db.models import Count, Sum
 from django.http import HttpResponse, JsonResponse
 from django.utils import timezone
@@ -21,10 +24,7 @@ from accounts.models import Account
 from donations.models import Donation
 from pots.models import Pot, PotPayout
 
-try:
-    from campaigns.models import Campaign
-except ImportError:
-    Campaign = None
+logger = logging.getLogger("jobs")
 
 
 class StatsResponseSerializer(serializers.Serializer):
@@ -141,14 +141,26 @@ def _payout_stats(qs):
     }
 
 
-def _campaign_stats(window_filter=None):
-    if Campaign is None:
+def _fetch_campaign_stats_from_dev():
+    """Fetch campaign stats from the dev deployment (which has the campaigns app
+    installed and indexes campaign data with USD computed).
+
+    The prod deployment does not have the campaigns app, so campaign data is
+    pulled over HTTP from `DEV_CAMPAIGN_STATS_URL` and merged into the same
+    daily-stats message. Returns a dict with `today`/`last_7_days`/`all_time`
+    keys (each `{"count", "raised_usd"}`), or `None` if the URL is unset or the
+    request fails — in which case the message simply omits campaign lines.
+    """
+    url = os.environ.get("DEV_CAMPAIGN_STATS_URL")
+    if not url:
         return None
-    qs = Campaign.objects.all() if window_filter is None else Campaign.objects.filter(**window_filter)
-    return {
-        "count": qs.count(),
-        "raised_usd": qs.aggregate(s=Sum("total_raised_amount_usd"))["s"] or 0,
-    }
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.warning("Failed to fetch campaign stats from dev (%s): %s", url, e)
+        return None
 
 
 def _build_daily_stats():
@@ -168,9 +180,10 @@ def _build_daily_stats():
     pots_7d = Pot.objects.filter(deployed_at__gte=seven_days_ago).count()
     pots_all = Pot.objects.count()
 
-    campaigns_today = _campaign_stats({"created_at__gte": today_start})
-    campaigns_7d = _campaign_stats({"created_at__gte": seven_days_ago})
-    campaigns_all = _campaign_stats()
+    campaign_stats = _fetch_campaign_stats_from_dev() or {}
+    campaigns_today = campaign_stats.get("today")
+    campaigns_7d = campaign_stats.get("last_7_days")
+    campaigns_all = campaign_stats.get("all_time")
 
     return {
         "date": now.strftime("%Y-%m-%d"),

--- a/base/celery.py
+++ b/base/celery.py
@@ -62,7 +62,7 @@ app.conf.beat_schedule = {
     },
     "post_daily_stats_to_signal": {
         "task": "indexer_app.tasks.post_daily_stats_to_signal",
-        "schedule": crontab(hour="12", minute="0"),  # Daily at 12:00 UTC
+        "schedule": crontab(hour="7", minute="0"),  # Daily at 07:00 UTC
         "options": {"queue": "beat_tasks"},
     },
 }

--- a/indexer_app/tasks.py
+++ b/indexer_app/tasks.py
@@ -1125,6 +1125,13 @@ def post_daily_stats_to_signal():
         SIGNAL_API_URL          base URL of signal-cli-rest-api (e.g. http://localhost:8080)
         SIGNAL_SENDER_NUMBER    registered Signal sender (E.164)
         SIGNAL_RECIPIENT        group id or phone number to send to
+
+    Optional env vars:
+        DEV_CAMPAIGN_STATS_URL  URL of the dev deployment's campaign-stats endpoint
+                                (e.g. https://dev.potlock.io/api/v1/stats/campaigns).
+                                Prod has no campaigns app, so campaign data is merged
+                                into this message from dev. If unset/unreachable, the
+                                message is sent without campaign lines.
     """
     import os
 


### PR DESCRIPTION
## What
Two changes to the daily POTLOCK metrics posted to Signal:

1. **Campaign data in the message.** Prod has no campaigns app, so the daily message dropped all campaign lines. It now fetches campaign stats from the dev deployment over HTTP (`DEV_CAMPAIGN_STATS_URL`, e.g. `https://dev.potlock.io/api/v1/stats/campaigns`) and merges them into the **same** message under TODAY / LAST 7 DAYS / ALL-TIME.
2. **Send time** moved from 12:00 UTC to **07:00 UTC** (5 hours earlier).

## Notes
- Requires the dev endpoint (separate PR into `dev`) to be deployed first.
- Set `DEV_CAMPAIGN_STATS_URL` on the prod server alongside the `SIGNAL_*` env vars. If unset/unreachable, the message still sends, just without campaign lines (graceful fallback).

## Files
- `base/api.py`: `_fetch_campaign_stats_from_dev()` + merge into `_build_daily_stats()`
- `base/celery.py`: schedule `12:00` → `07:00` UTC
- `indexer_app/tasks.py`: docstring note for the new env var